### PR TITLE
improve running from vscode tests sidebar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,11 +96,15 @@ export function activate(context: vscode.ExtensionContext) {
 
         const runTestQueue = async () => {
             const runner = new TestRunner(channel, errors);
-            await runner.run(
-                queue.map((q) => q.test),
-                run,
-                debug
-            );
+            try {
+                await runner.run(
+                    queue.map((q) => q.test),
+                    run,
+                    debug
+                );
+            } finally {
+                run.end();
+            }
 
             /*for (const { test, data } of queue) {
                 run.appendOutput(`Running ${test.id}\r\n`);
@@ -120,7 +124,6 @@ export function activate(context: vscode.ExtensionContext) {
                 run.appendOutput(`Completed ${test.id}\r\n`);
             }*/
 
-            run.end();
         };
 
         /*run.coverageProvider = {
@@ -136,7 +139,7 @@ export function activate(context: vscode.ExtensionContext) {
                         )
                     );
                 }
-
+ 
                 return coverage;
             },
         };*/
@@ -290,4 +293,4 @@ function startWatchingWorkspace(controller: vscode.TestController, fileChangedEm
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -329,6 +329,11 @@ export class TestRunner {
                         continue;
                     }
 
+                    // Don't send errors for passed steps!
+                    if (stepResult.status === "PASSED") {
+                        continue;
+                    }
+
                     const range = new vscode.Range(hook.sourceReference.location!.line, hook.sourceReference.location?.column ?? 0, hook.sourceReference.location!.line, 100);
                     const fullUri = workspace.uri.toString() + "/" + this.fixUri(hook.sourceReference.uri!);
                     handleError(stepResult, feature, fullUri, range, options, this.diagnosticCollection);

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -389,11 +389,14 @@ export class TestRunner {
                         let errorsCount = this.testCaseErrors.get(testCase.id) ?? 0;
                         this.testCaseErrors.set(testCase.id, errorsCount + 1);
                     } break;
+                    case TestStepResultStatus.SKIPPED: {
+                        options.skipped(step);
+                    } break;
                     default:
                         throw new Error(`Unhandled step result: ${stepResult.status}`);
                 }
 
-                }
+            }
 
                 if (objectData.testCaseFinished) {
                     const testCaseFinished = objectData.testCaseFinished;

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -331,7 +331,7 @@ export class TestRunner {
                     }
 
                     // Don't send errors for passed steps!
-                    if (stepResult.status === "PASSED") {
+                    if (stepResult.status === TestStepResultStatus.PASSED) {
                         continue;
                     }
 

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -22,7 +22,7 @@ export class TestRunner {
     private testCaseStartedToTestCase = new Map<string, TestCaseMessage>();
     private testCaseErrors = new Map<string, number>();
 
-    constructor(private logChannel: vscode.OutputChannel, private diagnosticCollection: vscode.DiagnosticCollection) {}
+    constructor(private logChannel: vscode.OutputChannel, private diagnosticCollection: vscode.DiagnosticCollection) { }
 
     private tryParseJson<T>(inputString: string): T | null {
         try {
@@ -398,51 +398,51 @@ export class TestRunner {
 
             }
 
-                if (objectData.testCaseFinished) {
-                    const testCaseFinished = objectData.testCaseFinished;
-                    const testCase = this.testCaseStartedToTestCase.get(testCaseFinished.testCaseStartedId);
-                    if (!testCase) {
-                        continue;
-                    }
-
-                    const pickle = this.picklesIndex.get(testCase.pickleId);
-                    if (!pickle) {
-                        continue;
-                    }
-
-                    const data = this.runnerData.get(this.fixUri(pickle.uri!));
-                    if (!data) {
-                        continue;
-                    }
-
-                    const scenarioId = pickle.astNodeIds[0];
-                    const scenario = data.feature.children.find((c) => {
-                        if (!c.scenario) {
-                            return false;
-                        }
-                        return c.scenario.id === scenarioId;
-                    });
-                    if (!scenario || !scenario.scenario) {
-                        continue;
-                    }
-
-                    const featureExpectedId = `${data!.uri}/${scenario.scenario.location.line}`;
-                    const feature = items.find((i) => i.id === featureExpectedId);
-                    if (!feature) {
-                        continue;
-                    }
-
-                    const errors = this.testCaseErrors.get(testCase.id) ?? 0;
-                    if (errors > 0) {
-                        options.failed(feature, new vscode.TestMessage("One or more steps failed"));
-                    } else {
-                        options.passed(feature);
-                    }
-
-                    options.end();
+            if (objectData.testCaseFinished) {
+                const testCaseFinished = objectData.testCaseFinished;
+                const testCase = this.testCaseStartedToTestCase.get(testCaseFinished.testCaseStartedId);
+                if (!testCase) {
+                    continue;
                 }
-            }
 
-            return { success: cucumberProcess.exitCode === 0 };
+                const pickle = this.picklesIndex.get(testCase.pickleId);
+                if (!pickle) {
+                    continue;
+                }
+
+                const data = this.runnerData.get(this.fixUri(pickle.uri!));
+                if (!data) {
+                    continue;
+                }
+
+                const scenarioId = pickle.astNodeIds[0];
+                const scenario = data.feature.children.find((c) => {
+                    if (!c.scenario) {
+                        return false;
+                    }
+                    return c.scenario.id === scenarioId;
+                });
+                if (!scenario || !scenario.scenario) {
+                    continue;
+                }
+
+                const featureExpectedId = `${data!.uri}/${scenario.scenario.location.line}`;
+                const feature = items.find((i) => i.id === featureExpectedId);
+                if (!feature) {
+                    continue;
+                }
+
+                const errors = this.testCaseErrors.get(testCase.id) ?? 0;
+                if (errors > 0) {
+                    options.failed(feature, new vscode.TestMessage("One or more steps failed"));
+                } else {
+                    options.passed(feature);
+                }
+
+                options.end();
+            }
         }
+
+        return { success: cucumberProcess.exitCode === 0 };
     }
+}


### PR DESCRIPTION
1. when running test with before/after hooks, stdout stream throws an error event.
(catch it using: 
`process.stdout.on('error', function (err) {
  console.log(err);
});`
causing the runner to not calling `run.end();`

2. tests prints to stdout are now redirected to the debug console.