### PR TITLE
allow configuration of test discovery paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ module.exports = {
 }
 ```
 
+### Specify Feature File Paths
+
+You can select which feature files you want to be used for test discovory
+The default is `**/*.feature`
+
+```json
+{
+    "cucumberTestRunner.featurePaths": "integration-tests/*.feature"
+}
+```
+
 ### Better Error detection and reporting
 
 Now the extension detects and reports errors in before and after hooks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cucumber-test-runner",
-    "version": "0.4.0",
+    "version": "0.5.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "cucumber-test-runner",
-            "version": "0.4.0",
+            "version": "0.5.2",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cucumber-test-runner",
     "displayName": "CucumberJS Test Runner",
     "description": "Allow to discover, run and debug cucumber-js tests",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "publisher": "balrog994",
     "license": "MIT",
     "icon": "docs/images/logo.png",
@@ -39,6 +39,11 @@
                     "type": "string",
                     "default": "",
                     "description": "The name of the cucumber-js configuration profile to use to run tests"
+                },
+                "cucumberTestRunner.featurePaths": {
+                    "type": "string",
+                    "default": "**/*.feature",
+                    "description": "The path expression for feature files to use to discover tests"
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -245,10 +245,12 @@ function getWorkspaceTestPatterns() {
     if (!vscode.workspace.workspaceFolders) {
         return [];
     }
-
+    const workspace = vscode.workspace.workspaceFolders![0];
+    const adapterConfig = vscode.workspace.getConfiguration("cucumberTestRunner", workspace.uri);
+    const featurePaths = adapterConfig.get<string>("featurePaths") ?? "**/*.feature";
     return vscode.workspace.workspaceFolders.map((workspaceFolder) => ({
         workspaceFolder,
-        pattern: new vscode.RelativePattern(workspaceFolder, "**/*.feature"),
+        pattern: new vscode.RelativePattern(workspaceFolder, featurePaths),
     }));
 }
 


### PR DESCRIPTION
use-case: one of our (mono) repos has multiple sets of feature files, and we really only want to run the _other_ tests locally

It seems like it _should_ be possible to inspect the `profile` to get the paths from that, but .. barring parsing and evaluating both cucumber.yml and cucumber.mjs I'm not sure how. Open to ideas, tho!

Maybe it would be also better to have the setting be [profile]: paths?